### PR TITLE
Implement cleanup script to avoid 409 conflicts

### DIFF
--- a/.github/workflows/deploy-infra.yml
+++ b/.github/workflows/deploy-infra.yml
@@ -38,12 +38,12 @@ jobs:
 
 
       - name: Initialize Terraform
-        run: terraform init
+        run: terraform init -var="credentials_file=${HOME}/gcp-key.json"
         env:
           GOOGLE_APPLICATION_CREDENTIALS: "${HOME}/gcp-key.json"
 
-      - name: Import existing resources
-        run: bash scripts/import_existing_resources.sh
+      - name: Delete existing resources
+        run: bash scripts/delete_existing_resources.sh
         env:
           GOOGLE_APPLICATION_CREDENTIALS: "${HOME}/gcp-key.json"
           DATA_BUCKET_NAME: ${{ secrets.DATA_BUCKET_NAME }}

--- a/scripts/delete_existing_resources.sh
+++ b/scripts/delete_existing_resources.sh
@@ -1,0 +1,44 @@
+#!/bin/bash
+set -e
+
+# Delete GCP resources if they exist, ignoring errors when they do not.
+
+PROJECT_ID=${PROJECT_ID:-$(gcloud config get-value project 2>/dev/null)}
+REGION=${REGION:-${1:-us-central1}}
+
+DATA_BUCKET_NAME=${DATA_BUCKET_NAME:-testados-rutas}
+FUNCTION_BUCKET_NAME=${FUNCTION_BUCKET_NAME:-testados-functions}
+EXPORT_BUCKET_NAME=${EXPORT_BUCKET_NAME:-testados-rutas-exportadas}
+
+# Ensure Terraform commands receive the credentials file path
+TF_VAR_credentials_file="${GOOGLE_APPLICATION_CREDENTIALS}"
+export TF_VAR_credentials_file
+
+# Delete Cloud Scheduler job if it exists
+if gcloud scheduler jobs describe export-csv-scheduler --location "$REGION" >/dev/null 2>&1; then
+  gcloud scheduler jobs delete export-csv-scheduler --location "$REGION" --quiet || true
+fi
+
+# Delete Pub/Sub topic if it exists
+if gcloud pubsub topics describe export-csv-topic >/dev/null 2>&1; then
+  gcloud pubsub topics delete export-csv-topic --quiet || true
+fi
+
+# Delete Cloud Functions if they exist
+if gcloud functions describe csvProcessor --region "$REGION" --gen2 >/dev/null 2>&1; then
+  gcloud functions delete csvProcessor --region "$REGION" --gen2 --quiet || true
+fi
+if gcloud functions describe exportCSV --region "$REGION" --gen2 >/dev/null 2>&1; then
+  gcloud functions delete exportCSV --region "$REGION" --gen2 --quiet || true
+fi
+
+# Delete storage buckets if they exist
+if gsutil ls -b "gs://$DATA_BUCKET_NAME" >/dev/null 2>&1; then
+  gsutil -m rm -r "gs://$DATA_BUCKET_NAME" || true
+fi
+if gsutil ls -b "gs://$FUNCTION_BUCKET_NAME" >/dev/null 2>&1; then
+  gsutil -m rm -r "gs://$FUNCTION_BUCKET_NAME" || true
+fi
+if gsutil ls -b "gs://$EXPORT_BUCKET_NAME" >/dev/null 2>&1; then
+  gsutil -m rm -r "gs://$EXPORT_BUCKET_NAME" || true
+fi


### PR DESCRIPTION
## Summary
- add script to delete existing GCP resources prior to deployment
- run the cleanup script from the deploy workflow instead of importing resources
- fix Terraform init to provide credentials file

## Testing
- `terraform fmt -check -recursive`
- `terraform init -backend=false` *(fails: could not connect to registry.terraform.io)*

------
https://chatgpt.com/codex/tasks/task_e_685ab1a283888328b96700705bb33b24