### PR TITLE
Preserve buckets and ensure creation

### DIFF
--- a/.github/workflows/deploy-infra.yml
+++ b/.github/workflows/deploy-infra.yml
@@ -51,6 +51,15 @@ jobs:
           EXPORT_BUCKET_NAME: ${{ secrets.EXPORT_BUCKET_NAME }}
           REGION: ${{ secrets.GCP_REGION }}
 
+      - name: Ensure and import resources
+        run: bash scripts/import_existing_resources.sh
+        env:
+          GOOGLE_APPLICATION_CREDENTIALS: "${HOME}/gcp-key.json"
+          DATA_BUCKET_NAME: ${{ secrets.DATA_BUCKET_NAME }}
+          FUNCTION_BUCKET_NAME: ${{ secrets.FUNCTION_BUCKET_NAME }}
+          EXPORT_BUCKET_NAME: ${{ secrets.EXPORT_BUCKET_NAME }}
+          REGION: ${{ secrets.GCP_REGION }}
+
       - name: Apply Terraform
         run: terraform apply -auto-approve -var="credentials_file=${HOME}/gcp-key.json"
         env:

--- a/scripts/delete_existing_resources.sh
+++ b/scripts/delete_existing_resources.sh
@@ -32,13 +32,5 @@ if gcloud functions describe exportCSV --region "$REGION" --gen2 >/dev/null 2>&1
   gcloud functions delete exportCSV --region "$REGION" --gen2 --quiet || true
 fi
 
-# Delete storage buckets if they exist
-if gsutil ls -b "gs://$DATA_BUCKET_NAME" >/dev/null 2>&1; then
-  gsutil -m rm -r "gs://$DATA_BUCKET_NAME" || true
-fi
-if gsutil ls -b "gs://$FUNCTION_BUCKET_NAME" >/dev/null 2>&1; then
-  gsutil -m rm -r "gs://$FUNCTION_BUCKET_NAME" || true
-fi
-if gsutil ls -b "gs://$EXPORT_BUCKET_NAME" >/dev/null 2>&1; then
-  gsutil -m rm -r "gs://$EXPORT_BUCKET_NAME" || true
-fi
+# Buckets are preserved between runs. They will be created if missing in
+# import_existing_resources.sh and should not be deleted here.


### PR DESCRIPTION
## Summary
- stop removing storage buckets in deletion script
- create buckets on the import script when missing
- run import script in the deploy workflow before applying Terraform

## Testing
- `terraform fmt -recursive -check` *(fails: command not found)*

------
https://chatgpt.com/codex/tasks/task_e_685ac17c16188328affee050027bedf6