### PR TITLE
Remove IAM member resource causing apply failure

### DIFF
--- a/main.tf
+++ b/main.tf
@@ -9,12 +9,6 @@ data "google_project" "current" {
   project_id = var.project_id
 }
 
-# Allow the Cloud Storage service account to publish events for CloudEvent triggers
-resource "google_project_iam_member" "gcs_pubsub_publisher" {
-  project = data.google_project.current.project_id
-  role    = "roles/pubsub.publisher"
-  member  = "serviceAccount:service-${data.google_project.current.number}@gs-project-accounts.iam.gserviceaccount.com"
-}
 
 # Detectar si el bucket de datos ya existe
 data "google_storage_bucket" "existing_data_bucket" {


### PR DESCRIPTION
## Summary
- remove `google_project_iam_member.gcs_pubsub_publisher` because the IAM policy update fails without permissions

## Testing
- `terraform fmt -check`
- `terraform init -backend=false` *(fails: could not connect to registry.terraform.io)*

------
https://chatgpt.com/codex/tasks/task_e_685acc1b94a08328bf95dd07ab85e402