### PR TITLE
Limpia valores antes de guardar

### DIFF
--- a/function/csv_processor/main.py
+++ b/function/csv_processor/main.py
@@ -1,5 +1,6 @@
 import csv
 import os
+import re
 from google.cloud import firestore, storage
 
 CAMPOS = [
@@ -17,6 +18,14 @@ def detectar_delimitador(linea: str) -> str:
     if ',' in linea:
         return ','
     raise ValueError('Unknown delimiter')
+
+def limpiar_valor(valor: str) -> str:
+    valor = re.sub(r' {2,}', ' ', valor).strip()
+    if valor.isdigit():
+        valor = valor.lstrip('0')
+        if valor == '':
+            return ''
+    return '' if valor == '0' else valor
 
 def procesar_csv(datos, contexto):
     nombre_bucket = datos['bucket']
@@ -53,7 +62,7 @@ def procesar_csv(datos, contexto):
 
     subcoleccion = ref_ruta.collection('RutaRecorrido')
     for indice, fila in enumerate(lector):
-        fila = {k: ('' if v == '0' else v) for k, v in fila.items()}
+        fila = {k: limpiar_valor(v) for k, v in fila.items()}
         subcoleccion.document(str(indice)).set(fila)
 
     print(f"Processed {len(lineas)} lines from {nombre_archivo}.")


### PR DESCRIPTION
## Resumen
- Elimina ceros iniciales en campos numéricos y reduce espacios repetidos.
- Aplica limpieza a cada fila antes de guardar en Firestore.

## Pruebas
- `python -m py_compile function/csv_processor/main.py`


------
https://chatgpt.com/codex/tasks/task_e_688f5a0387a48328a23e8e84d1d0f01a