### PR TITLE
Agregar rol de lectura para bucket de rutas

### DIFF
--- a/main.tf
+++ b/main.tf
@@ -37,6 +37,13 @@ resource "google_storage_bucket" "data_bucket" {
   }
 }
 
+resource "google_storage_bucket_iam_member" "lector_rutas" {
+  bucket     = coalesce(data.google_storage_bucket.existing_data_bucket.name, var.data_bucket_name)
+  role       = "roles/storage.objectViewer"
+  member     = "serviceAccount:${var.cuenta_servicio_web}"
+  depends_on = [google_storage_bucket.data_bucket]
+}
+
 # Crear el bucket de funciones solo si no existe
 resource "google_storage_bucket" "function_bucket" {
   count    = data.google_storage_bucket.existing_function_bucket.id == null ? 1 : 0

--- a/variables.tf
+++ b/variables.tf
@@ -33,3 +33,9 @@ variable "credentials_file" {
   type        = string
   default     = ""
 }
+
+variable "cuenta_servicio_web" {
+  description = "Cuenta de servicio de la app web"
+  type        = string
+  default     = ""
+}


### PR DESCRIPTION
## Resumen
- Permite a la cuenta de servicio de la web leer objetos privados del bucket de rutas
- Agrega variable para definir la cuenta de servicio de la app

## Pruebas
- `terraform fmt`
- `terraform init -backend=false` (falla por Forbidden al contactar registry)


------
https://chatgpt.com/codex/tasks/task_e_6890ed43367c8328a386edb1ccaf71c5